### PR TITLE
Polish markdown in blocks

### DIFF
--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -76,15 +76,16 @@
    :text-decoration "none"
    :color (color :link-color)
    ::stylefy/manual [[:.formatting {:color (color :body-text-color :opacity-low)}]
-                   [:&:hover {:text-decoration "underline"}]]})
+                     [:&:hover {:text-decoration "underline"}]]})
 
 
-(def autolink {:cursor "pointer"
-               :text-decoration "none"
-               ::stylefy/manual [[:.formatting {:color (color :body-text-color :opacity-low)}]
-                                 [:.contents {:color (color :link-color)
-                                              :text-decoration "none"}]
-                                 [:&:hover [:.contents {:text-decoration "underline"}]]]})
+(def autolink
+  {:cursor "pointer"
+   :text-decoration "none"
+   ::stylefy/manual [[:.formatting {:color (color :body-text-color :opacity-low)}]
+                     [:.contents {:color (color :link-color)
+                                  :text-decoration "none"}]
+                     [:&:hover [:.contents {:text-decoration "underline"}]]]})
 
 
 (def block-ref

--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -75,7 +75,16 @@
   {:cursor "pointer"
    :text-decoration "none"
    :color (color :link-color)
-   ::stylefy/mode [[:hover {:text-decoration "underline"}]]})
+   ::stylefy/manual [[:.formatting {:color (color :body-text-color :opacity-low)}]
+                   [:&:hover {:text-decoration "underline"}]]})
+
+
+(def autolink {:cursor "pointer"
+               :text-decoration "none"
+               ::stylefy/manual [[:.formatting {:color (color :body-text-color :opacity-low)}]
+                                 [:.contents {:color (color :link-color)
+                                              :text-decoration "none"}]
+                                 [:&:hover [:.contents {:text-decoration "underline"}]]]})
 
 
 (def block-ref
@@ -198,21 +207,21 @@
                                                       :href   url
                                                       :target "_blank"})
                               text])
-     :autolink             (fn [{:keys [text target]}]
-                             [:span
-                              [:span {:class "formatting"} "<"]
-                              [:a (use-style url-link {:class  "url-link"
-                                                       :href target
-                                                       :target "_blank"})
-                               text]
-                              [:span {:class "formatting"} ">"]])
      :link                 (fn [{:keys [text target title]}]
-                             [:a (cond-> (use-style url-link {:class  "url-link"
+                             [:a (cond-> (use-style url-link {:class  "url-link contents"
                                                               :href target
                                                               :target "_blank"})
                                    (string? title)
                                    (assoc :title title))
                               text])
+     :autolink             (fn [{:keys [text target]}]
+                             [:span (use-style autolink)
+                              [:span {:class "formatting"} "<"]
+                              [:a {:class  "autolink contents"
+                                   :href target
+                                   :target "_blank"}
+                               text]
+                              [:span {:class "formatting"} ">"]])
      :paragraph            (fn [& contents]
                              (println "paragraph contents " (pr-str contents))
                              (apply conj [:p] (if (= 1 (count contents))

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -293,8 +293,24 @@
                                           :color (color :background-color)}]]
                               [:&:active {:transform "scale(0.9)"}]]]
 
-                     [:mark.contents.highlight {:padding "0 2px"
-                                                :background-color "#ffeb7a"}]]})
+                     [:h1 :h2 :h3 :h4 :h5 :h6 {:margin "0"
+                                               :color (color :body-text-color :opacity-higher)
+                                               :font-weight "500"}]
+                     [:h1 {:padding "0"
+                           :margin-block-start "-0.1em"}]
+                     [:h2 {:padding "0"}]
+                     [:h3 {:padding "0"}]
+                     [:h4 {:padding "0.25em 0"}]
+                     [:h5 {:padding "1em 0"}]
+                     [:h6 {:text-transform "uppercase"
+                           :letter-spacing "0.06em"
+                           :padding "1em 0"}]
+                     [.katex {}]
+[.codemirror {}]
+
+                     [:mark.contents.highlight {:padding "0 0.2em"
+                                                :border-radius "0.125rem"
+                                                :background-color (color :highlight-color)}]]})
 
 
 (stylefy/class "block-content" block-content-style)

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -318,6 +318,17 @@
                                    :color (color :body-text-color :opacity-high)}
                       [:p {:padding-bottom "1em"}]
                       [:p:last-child {:padding-bottom "0"}]]
+                     [:.CodeMirror {:background (color :background-plus-1)
+                                    :margin "0.25rem 0"
+                                    :border-radius "0.25rem"
+                                    :font-size "85%"
+                                    :color (color :body-text-color)
+                                    :font-family "IBM Plex Mono"}]
+                     [:.CodeMirror-gutters {:border-right "1px solid transparent"
+                                            :background (color :background-plus-2)}]
+                     [:.CodeMirror-cursor {:border-left-color (color :link-color)}]
+                     [:.CodeMirror-lines {:padding 0}]
+                     [:.CodeMirror-linenumber {:color (color :body-text-color :opacity-med)}]
 
                      [:mark.contents.highlight {:padding "0 0.2em"
                                                 :border-radius "0.125rem"

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -305,8 +305,19 @@
                      [:h6 {:text-transform "uppercase"
                            :letter-spacing "0.06em"
                            :padding "1em 0"}]
-                     [.katex {}]
-                     [.codemirror {}]
+                     [:p {:margin "0"
+                          :padding-bottom "1em"}]
+                     [:blockquote {:margin-block-end "1em"
+                                   :margin-inline "0.5em"
+                                   :margin-block "1em"
+                                   :padding-block "0.5em"
+                                   :padding-inline "1.5em"
+                                   :border-radius "0.25em"
+                                   :background (color :background-plus-1)
+                                   :border-inline-start [["0.25em solid" (color :body-text-color :opacity-lower)]]
+                                   :color (color :body-text-color :opacity-high)}
+                      [:p {:padding-bottom "1em"}]
+                      [:p:last-child {:padding-bottom "0"}]]
 
                      [:mark.contents.highlight {:padding "0 0.2em"
                                                 :border-radius "0.125rem"

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -306,7 +306,7 @@
                            :letter-spacing "0.06em"
                            :padding "1em 0"}]
                      [.katex {}]
-[.codemirror {}]
+                     [.codemirror {}]
 
                      [:mark.contents.highlight {:padding "0 0.2em"
                                                 :border-radius "0.125rem"

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -307,25 +307,24 @@
                            :padding "1em 0"}]
                      [:p {:margin "0"
                           :padding-bottom "1em"}]
-                     [:blockquote {:margin-block-end "1em"
-                                   :margin-inline "0.5em"
-                                   :margin-block "1em"
-                                   :padding-block "0.5em"
+                     [:blockquote {:margin-inline "0.5em"
+                                   :margin-block "0.125rem"
+                                   :padding-block "calc(0.5em - 0.125rem - 0.125rem)"
                                    :padding-inline "1.5em"
                                    :border-radius "0.25em"
-                                   :background (color :background-plus-1)
+                                   :background (color :background-minus-1)
                                    :border-inline-start [["0.25em solid" (color :body-text-color :opacity-lower)]]
                                    :color (color :body-text-color :opacity-high)}
                       [:p {:padding-bottom "1em"}]
                       [:p:last-child {:padding-bottom "0"}]]
-                     [:.CodeMirror {:background (color :background-plus-1)
-                                    :margin "0.25rem 0"
+                     [:.CodeMirror {:background (color :background-minus-1)
+                                    :margin "0.125rem 0.5rem"
                                     :border-radius "0.25rem"
                                     :font-size "85%"
                                     :color (color :body-text-color)
                                     :font-family "IBM Plex Mono"}]
                      [:.CodeMirror-gutters {:border-right "1px solid transparent"
-                                            :background (color :background-plus-2)}]
+                                            :background (color :background-minus-1)}]
                      [:.CodeMirror-cursor {:border-left-color (color :link-color)}]
                      [:.CodeMirror-lines {:padding 0}]
                      [:.CodeMirror-linenumber {:color (color :body-text-color :opacity-med)}]


### PR DESCRIPTION
Polish for...

- Headings
- Paragraphs
- Codemirror
- Blockquotes
  - Paragraphs in blockquotes
- Highlights
- Autolinks

Also fixes a style issue with url-links due to a typo

![Screen Shot 2021-04-16 at 11 46 30 PM](https://user-images.githubusercontent.com/98312/115100902-f93f5280-9f0d-11eb-913d-0fb29970b23e.png)