### PR TITLE
Sid migrate `:drop/...` events

### DIFF
--- a/src/cljc/athens/common_db.cljc
+++ b/src/cljc/athens/common_db.cljc
@@ -214,6 +214,31 @@
        linked-refs))
 
 
+(defn minus-after
+  [db eid order x]
+  (->> (d/q '[:find ?ch ?new-o
+              :keys db/id block/order
+              :in $ % ?p ?at ?x
+              :where (minus-after ?p ?at ?ch ?new-o ?x)]
+            db
+            rules
+            eid
+            order
+            x)))
+
+
+(defn plus-after
+  [db eid order x]
+  (->> (d/q '[:find ?ch ?new-o
+              :keys db/id block/order
+              :in $ % ?p ?at ?x
+              :where (plus-after ?p ?at ?ch ?new-o ?x)]
+            db
+            rules
+            eid
+            order
+            x)))
+
 (defn get-page-document
   "Retrieves whole page 'document', meaning with children."
   [db eid]

--- a/src/cljc/athens/common_db.cljc
+++ b/src/cljc/athens/common_db.cljc
@@ -269,30 +269,6 @@
                           db))]
     (= (count parents) 1)))
 
-(defn minus-after
-  [db eid order x]
-  (->> (d/q '[:find ?ch ?new-o
-              :keys db/id block/order
-              :in $ % ?p ?at ?x
-              :where (minus-after ?p ?at ?ch ?new-o ?x)]
-            db
-            rules
-            eid
-            order
-            x)))
-
-
-(defn plus-after
-  [db eid order x]
-  (->> (d/q '[:find ?ch ?new-o
-              :keys db/id block/order
-              :in $ % ?p ?at ?x
-              :where (plus-after ?p ?at ?ch ?new-o ?x)]
-            db
-            rules
-            eid
-            order
-            x)))
 
 (defn- shape-parent-query
   "Normalize path from deeply nested block to root node."

--- a/src/cljc/athens/common_events.cljc
+++ b/src/cljc/athens/common_events.cljc
@@ -290,6 +290,19 @@
                      :target-eid target-eid}}))
 
 
+(defn build-drop-multi-child-event
+  "Builds `:datascript/drop-multi-child` event with:
+  - `source-uids` : Vector of uids of the selected source blocks
+  - `target-eid`  : `:db/id` of the target block"
+  [last-tx source-uids target-eid]
+  (let [event-id (gen-event-id)]
+    {:event/id      event-id
+     :event/last-tx last-tx
+     :event/type    :datascript/drop-multi-child
+     :event/args    {:source-uids source-uids
+                     :target-eid  target-eid}}))
+
+
 (defn build-drop-link-child-event
   "Builds `:datascript/drop-link-child` event with:
   - `source-uid` : uid of the source block

--- a/src/cljc/athens/common_events.cljc
+++ b/src/cljc/athens/common_events.cljc
@@ -290,16 +290,16 @@
                      :target-eid target-eid}}))
 
 
-(defn build-drop-diff-event
-  "Builds `:datascript/drop-diff` event with:
+(defn build-drop-diff-parent-event
+  "Builds `:datascript/drop-diff-parent` event with:
   - `source-uid` : uid of the source block
   - `target-uid` : uid of the target block
   - `drag-target`: defines where is the block dragged it can be :above, :below, :child"
-  [last-tx drag-target source-uid target-uid ]
+  [last-tx drag-target source-uid target-uid]
   (let [event-id (gen-event-id)]
     {:event/id      event-id
      :event/last-tx last-tx
-     :event/type    :datascript/drop-child
+     :event/type    :datascript/drop-diff-parent
      :event/args    {:source-uid  source-uid
                      :target-uid  target-uid
                      :drag-target drag-target}}))

--- a/src/cljc/athens/common_events.cljc
+++ b/src/cljc/athens/common_events.cljc
@@ -290,6 +290,19 @@
                      :target-eid target-eid}}))
 
 
+(defn build-drop-link-child-event
+  "Builds `:datascript/drop-link-child` event with:
+  - `source-uid` : uid of the source block
+  - `target-eid` : `:db/id` of the target block"
+  [last-tx source-uid target-eid]
+  (let [event-id (gen-event-id)]
+    {:event/id      event-id
+     :event/last-tx last-tx
+     :event/type    :datascript/drop-link-child
+     :event/args    {:source-uid source-uid
+                     :target-eid target-eid}}))
+
+
 (defn build-drop-diff-parent-event
   "Builds `:datascript/drop-diff-parent` event with:
   - `source-uid` : uid of the source block

--- a/src/cljc/athens/common_events.cljc
+++ b/src/cljc/athens/common_events.cljc
@@ -318,6 +318,21 @@
                      :drag-target drag-target}}))
 
 
+(defn build-drop-link-diff-parent-event
+  "Builds `:datascript/drop-link-diff-parent` event with:
+  - `source-uid` : uid of the source block
+  - `target-uid` : uid of the target block
+  - `drag-target`: defines where is the block dragged it can be :above, :below, :child"
+  [last-tx drag-target source-uid target-uid]
+  (let [event-id (gen-event-id)]
+    {:event/id      event-id
+     :event/last-tx last-tx
+     :event/type    :datascript/drop-link-diff-parent
+     :event/args    {:source-uid  source-uid
+                     :target-uid  target-uid
+                     :drag-target drag-target}}))
+
+
 ;; - presence events
 
 (defn build-presence-hello-event

--- a/src/cljc/athens/common_events.cljc
+++ b/src/cljc/athens/common_events.cljc
@@ -280,40 +280,40 @@
 (defn build-drop-child-event
   "Builds `:datascript/drop-child` event with:
   - `source-uid` : uid of the source block
-  - `target-eid` : `:db/id` of the target block"
-  [last-tx source-uid target-eid]
+  - `target-uid` : uid of the target block"
+  [last-tx source-uid target-uid]
   (let [event-id (gen-event-id)]
     {:event/id      event-id
      :event/last-tx last-tx
      :event/type    :datascript/drop-child
      :event/args    {:source-uid source-uid
-                     :target-eid target-eid}}))
+                     :target-uid target-uid}}))
 
 
 (defn build-drop-multi-child-event
   "Builds `:datascript/drop-multi-child` event with:
   - `source-uids` : Vector of uids of the selected source blocks
-  - `target-eid`  : `:db/id` of the target block"
-  [last-tx source-uids target-eid]
+  - `target-uid`  : uid of the target block"
+  [last-tx source-uids target-uid]
   (let [event-id (gen-event-id)]
     {:event/id      event-id
      :event/last-tx last-tx
      :event/type    :datascript/drop-multi-child
      :event/args    {:source-uids source-uids
-                     :target-eid  target-eid}}))
+                     :target-uid  target-uid}}))
 
 
 (defn build-drop-link-child-event
   "Builds `:datascript/drop-link-child` event with:
   - `source-uid` : uid of the source block
-  - `target-eid` : `:db/id` of the target block"
-  [last-tx source-uid target-eid]
+  - `target-uid` : uid of the target block"
+  [last-tx source-uid target-uid]
   (let [event-id (gen-event-id)]
     {:event/id      event-id
      :event/last-tx last-tx
      :event/type    :datascript/drop-link-child
      :event/args    {:source-uid source-uid
-                     :target-eid target-eid}}))
+                     :target-eid target-uid}}))
 
 
 (defn build-drop-diff-parent-event

--- a/src/cljc/athens/common_events.cljc
+++ b/src/cljc/athens/common_events.cljc
@@ -277,6 +277,19 @@
                      :new-uid new-uid}}))
 
 
+(defn build-drop-child-event
+  "Builds `:datascript/drop-child` event with:
+  - `source-uid` : uid of the source block
+  - `target-eid` : `:db/id` of the target block"
+  [last-tx source-uid target-uid]
+  (let [event-id (gen-event-id)]
+    {:event/id      event-id
+     :event/last-tx last-tx
+     :event/type    :datascript/drop-child
+     :event/args    {:source-uid source-uid
+                     :target-eid target-uid}}))
+
+
 ;; - presence events
 
 (defn build-presence-hello-event

--- a/src/cljc/athens/common_events.cljc
+++ b/src/cljc/athens/common_events.cljc
@@ -313,7 +313,7 @@
      :event/last-tx last-tx
      :event/type    :datascript/drop-link-child
      :event/args    {:source-uid source-uid
-                     :target-eid target-uid}}))
+                     :target-uid target-uid}}))
 
 
 (defn build-drop-diff-parent-event

--- a/src/cljc/athens/common_events.cljc
+++ b/src/cljc/athens/common_events.cljc
@@ -320,7 +320,9 @@
   "Builds `:datascript/drop-diff-parent` event with:
   - `source-uid` : uid of the source block
   - `target-uid` : uid of the target block
-  - `drag-target`: defines where is the block dragged it can be :above, :below, :child"
+  - `drag-target`: defines where is the block dragged it can be
+     - :above or :below the target block
+     - a :child (first block) under some block "
   [last-tx drag-target source-uid target-uid]
   (let [event-id (gen-event-id)]
     {:event/id      event-id
@@ -335,7 +337,9 @@
   "Builds `:datascript/drop-link-diff-parent` event with:
   - `source-uid` : uid of the source block
   - `target-uid` : uid of the target block
-  - `drag-target`: defines where is the block dragged it can be :above, :below, :child"
+  - `drag-target`: defines where is the block dragged it can be
+     - :above or :below the target block
+     - a :child (first block) under some block"
   [last-tx drag-target source-uid target-uid]
   (let [event-id (gen-event-id)]
     {:event/id      event-id

--- a/src/cljc/athens/common_events.cljc
+++ b/src/cljc/athens/common_events.cljc
@@ -281,13 +281,28 @@
   "Builds `:datascript/drop-child` event with:
   - `source-uid` : uid of the source block
   - `target-eid` : `:db/id` of the target block"
-  [last-tx source-uid target-uid]
+  [last-tx source-uid target-eid]
   (let [event-id (gen-event-id)]
     {:event/id      event-id
      :event/last-tx last-tx
      :event/type    :datascript/drop-child
      :event/args    {:source-uid source-uid
-                     :target-eid target-uid}}))
+                     :target-eid target-eid}}))
+
+
+(defn build-drop-diff-event
+  "Builds `:datascript/drop-diff` event with:
+  - `source-uid` : uid of the source block
+  - `target-uid` : uid of the target block
+  - `drag-target`: defines where is the block dragged it can be :above, :below, :child"
+  [last-tx drag-target source-uid target-uid ]
+  (let [event-id (gen-event-id)]
+    {:event/id      event-id
+     :event/last-tx last-tx
+     :event/type    :datascript/drop-child
+     :event/args    {:source-uid  source-uid
+                     :target-uid  target-uid
+                     :drag-target drag-target}}))
 
 
 ;; - presence events

--- a/src/cljc/athens/common_events/resolver.cljc
+++ b/src/cljc/athens/common_events/resolver.cljc
@@ -84,7 +84,7 @@
                                                {:db/id           [:block/uid uid]
                                                 :block/order     (+ order existing-page-block-count)
                                                 :block/_children [:block/uid new-parent-uid]})
-                                       old-page-kids)
+                                         old-page-kids)
         delete-page                     [:db/retractEntity [:block/uid uid]]
         new-datoms                      (concat [delete-page]
                                           new-linked-refs
@@ -358,8 +358,10 @@
 
 (defmethod resolve-event-to-tx :datascript/drop-child
   [db {:event/keys [args]}]
+  (println "resolver :datascript/drop-child args" (pr-str args))
   (let [{:keys [source-uid
-                target-eid]}               args
+                target-uid]}               args
+        {target-eid :db/id}                (common-db/get-block  db [:block/uid target-uid])
         {source-block-order :block/order}  (common-db/get-block  db [:block/uid source-uid])
         {source-parent-eid :db/id}         (common-db/get-parent db [:block/uid source-uid])
         new-source-block                   {:block/uid   source-uid
@@ -381,8 +383,10 @@
 
 (defmethod resolve-event-to-tx :datascript/drop-multi-child
   [db {:event/keys [args]}]
+  (println "resolver :datascript/drop-multi-child args" (pr-str args))
   (let [{:keys [source-uids
-                target-eid]}                args
+                target-uid]}                args
+        {target-eid :db/id}                 (common-db/get-block  db [:block/uid target-uid])
         source-blocks                       (mapv #(common-db/get-block  db [:block/uid %]) source-uids)
         source-parents                      (mapv #(common-db/get-parent db [:block/uid %]) source-uids)
         last-source-order                   (:block/order (last source-blocks))
@@ -419,8 +423,10 @@
 
 (defmethod resolve-event-to-tx :datascript/drop-link-child
   [db {:event/keys [args]}]
+  (println "resolver :datascript/drop-link-child args" (pr-str args))
   (let [{:keys [source-uid
-                target-eid]}               args
+                target-uid]}               args
+        {target-eid :db/id}                (common-db/get-block  db [:block/uid target-uid])
         new-uid                            (gen-block-uid)
         new-string                         (str "((" source-uid "))")
         new-source-block                   {:block/uid    new-uid
@@ -438,6 +444,7 @@
 
 (defmethod resolve-event-to-tx :datascript/drop-diff-parent
   [db {:event/keys [args]}]
+  (println "resolver :datascript/drop-diff-parent args" (pr-str args))
   (let [{:keys [drag-target
                 source-uid
                 target-uid]}                args
@@ -471,6 +478,7 @@
 
 (defmethod resolve-event-to-tx :datascript/drop-link-diff-parent
   [db {:event/keys [args]}]
+  (println "resolver :datascript/drop-link-diff-parent args" (pr-str args))
   (let [{:keys [drag-target
                 source-uid
                 target-uid]}                args

--- a/src/cljc/athens/common_events/resolver.cljc
+++ b/src/cljc/athens/common_events/resolver.cljc
@@ -359,7 +359,7 @@
 (defmethod resolve-event-to-tx :datascript/drop-child
   [db {:event/keys [args]}]
   (let [{:keys [source-uid
-                target-eid]} args
+                target-eid]}               args
         {source-block-order :block/order}  (common-db/get-block  db [:block/uid source-uid])
         {source-parent-eid :db/id}         (common-db/get-parent db [:block/uid source-uid])
         new-source-block                   {:block/uid   source-uid
@@ -376,6 +376,25 @@
                                             new-source-parent
                                             new-target-parent]]
     (println "resolver :datascript/drop-child tx-data" (pr-str tx-data))
+    tx-data))
+
+
+(defmethod resolve-event-to-tx :datascript/drop-link-child
+  [db {:event/keys [args]}]
+  (let [{:keys [source-uid
+                target-eid]}               args
+        new-uid                            (gen-block-uid)
+        new-string                         (str "((" source-uid "))")
+        new-source-block                   {:block/uid    new-uid
+                                            :block-string new-string
+                                            :block/order  0
+                                            :block.open   true}
+        reindex-target-parent              (common-db/inc-after db target-eid -1)
+        new-target-parent                  {:db/id          target-eid
+                                            :block/children (conj reindex-target-parent new-source-block)}
+        tx-data                            [new-source-block
+                                            new-target-parent]]
+    (println "resolver :datascript/drop-link-child tx-data" (pr-str tx-data))
     tx-data))
 
 

--- a/src/cljc/athens/common_events/resolver.cljc
+++ b/src/cljc/athens/common_events/resolver.cljc
@@ -595,6 +595,7 @@
                                              :block/children reindex-target-parent}
         tx-data                             [new-target-parent]]
     (println "resolver :datascript/drop-link-diff-parent tx-data" (pr-str tx-data))
+    tx-data))
 
     
 (defmethod resolve-event-to-tx :datascript/left-sidebar-drop-above
@@ -640,5 +641,4 @@
                             [(dec ?order) ?new-order]]
                           db source-order (inc target-order) between)
                      (concat [new-source]))]
-
     tx-data))

--- a/src/cljc/athens/common_events/resolver.cljc
+++ b/src/cljc/athens/common_events/resolver.cljc
@@ -430,15 +430,14 @@
         new-uid                            (gen-block-uid)
         new-string                         (str "((" source-uid "))")
         new-source-block                   {:block/uid    new-uid
-                                            :block-string new-string
+                                            :block/string new-string
                                             :block/order  0
-                                            :block.open   true}
+                                            :block/open   true}
         reindex-target-parent              (common-db/inc-after db target-eid -1)
         new-target-parent                  {:db/id          target-eid
                                             :block/children (conj reindex-target-parent new-source-block)}
         tx-data                            [new-source-block
                                             new-target-parent]]
-    (println "resolver :datascript/drop-link-child tx-data" (pr-str tx-data))
     tx-data))
 
 
@@ -472,7 +471,7 @@
         tx-data                             [retract
                                              new-source-parent
                                              new-target-parent]]
-    (js/console.debug "resolver :datascript/drop-diff-parent tx-data" (pr-str tx-data))
+    (println "resolver :datascript/drop-diff-parent tx-data" (pr-str tx-data))
     tx-data))
 
 
@@ -486,11 +485,11 @@
         {target-parent-eid  :db/id}         (common-db/get-parent db [:block/uid target-uid])
         new-uid                             (gen-block-uid)
         new-string                          (str "((" source-uid "))")
-        new-block                           {:db/id        new-uid
-                                             :block/string new-string
-                                             :block/order  (if (= drag-target :above)
-                                                             target-block-order
-                                                             (inc target-block-order))}
+        new-block                           {:block/uid        new-uid
+                                             :block/string     new-string
+                                             :block/order      (if (= drag-target :above)
+                                                                 target-block-order
+                                                                 (inc target-block-order))}
         reindex-target-parent               (concat
                                               [new-block]
                                               (common-db/inc-after db target-parent-eid (if (= drag-target :above)
@@ -499,5 +498,5 @@
         new-target-parent                   {:db/id          target-parent-eid
                                              :block/children reindex-target-parent}
         tx-data                             [new-target-parent]]
-    (js/console.debug "resolver :datascript/drop-link-diff-parent tx-data" (pr-str tx-data))
+    (println "resolver :datascript/drop-link-diff-parent tx-data" (pr-str tx-data))
     tx-data))

--- a/src/cljc/athens/common_events/resolver.cljc
+++ b/src/cljc/athens/common_events/resolver.cljc
@@ -388,13 +388,13 @@
 
 (defmethod resolve-event-to-tx :datascript/drop-multi-child
   [db {:event/keys [args]}]
-  "Drop multiple selected blocks as child to some other block
-   - source-parent: The block from which all the blocks are selected and removed
-   - target-parent: The block under which all the blocks are dropped
-   - DnD          : Short for dragged and dropped
-   After the selected blocks are DnD we need to reindex the remaining children of source-parent
-   and target-parent as a result all the children of source-parent have their order decreased
-   and the previous children under target-parent have their block order increased "
+  ;; Drop multiple selected blocks as child to some other block
+  ;; - source-parent: The block from which all the blocks are selected and removed
+  ;; - target-parent: The block under which all the blocks are dropped
+  ;; - DnD          : Short for dragged and dropped
+  ;; After the selected blocks are DnD we need to reindex the remaining children of source-parent
+  ;; and target-parent as a result all the children of source-parent have their order decreased
+  ;; and the previous children under target-parent have their block order increased
   (println "resolver :datascript/drop-multi-child args" (pr-str args))
   (let [{:keys [source-uids
                 target-uid]}                args
@@ -456,15 +456,15 @@
 
 (defmethod resolve-event-to-tx :datascript/drop-diff-parent
   [db {:event/keys [args]}]
-  "Drop selected block under some other block not as a child
-   - source-parent: The block from which the block is selected and removed
-   - target-parent: The block under which all the blocks are dropped
-   - DnD          : Short for dragged and dropped
-   - After the selected block is DnD we need to reindex the remaining children of source-parent
-     and target-parent as a result all the children of source-parent have their order decreased
-     and the previous children under target-parent have their block order increased
-   - drag-target affects the calculation of till which block all the blocks under source-parent or
-     target-parent need to be re-indexed."
+  ;; Drop selected block under some other block not as a child
+  ;; - source-parent: The block from which the block is selected and removed
+  ;; - target-parent: The block under which all the blocks are dropped
+  ;; - DnD          : Short for dragged and dropped
+  ;; After the selected block is DnD we need to reindex the remaining children of source-parent
+  ;; and target-parent as a result all the children of source-parent have their order decreased
+  ;; and the previous children under target-parent have their block order increased
+  ;; drag-target affects the calculation of till which block all the blocks under source-parent or
+  ;; target-parent need to be re-indexed.
   (println "resolver :datascript/drop-diff-parent args" (pr-str args))
   (let [{:keys [drag-target
                 source-uid

--- a/src/cljc/athens/common_events/resolver.cljc
+++ b/src/cljc/athens/common_events/resolver.cljc
@@ -379,7 +379,7 @@
     tx-data))
 
 
-(defmethod resolve-event-to-tx :datascript/drop-diff
+(defmethod resolve-event-to-tx :datascript/drop-diff-parent
   [db {:event/keys [args]}]
   (let [{:keys [drag-target
                 source-uid

--- a/src/cljc/athens/common_events/resolver.cljc
+++ b/src/cljc/athens/common_events/resolver.cljc
@@ -436,8 +436,8 @@
         reindex-target-parent              (common-db/inc-after db target-eid -1)
         new-target-parent                  {:db/id          target-eid
                                             :block/children (conj reindex-target-parent new-source-block)}
-        tx-data                            [new-source-block
-                                            new-target-parent]]
+        tx-data                            [new-target-parent]]
+    (println "resolver :datascript/drop-link-child tx-data" (pr-str tx-data))
     tx-data))
 
 
@@ -460,8 +460,8 @@
         reindex-target-parent               (concat
                                               [new-block]
                                               (common-db/inc-after db target-parent-eid (if (= drag-target :above)
-                                                                                           (dec target-block-order)
-                                                                                           target-block-order)))
+                                                                                          (dec target-block-order)
+                                                                                          target-block-order)))
         retract                             [:db/retract     source-parent-eid
                                              :block/children source-block-eid]
         new-source-parent                   {:db/id          source-parent-eid

--- a/src/cljc/athens/common_events/schema.cljc
+++ b/src/cljc/athens/common_events/schema.cljc
@@ -166,7 +166,7 @@
   [:map
    [:event/args
     [:map
-     [:source-uids vector?
+     [:source-uids [:vector string?]
       :target-uid  string?]]]])
 
 

--- a/src/cljc/athens/common_events/schema.cljc
+++ b/src/cljc/athens/common_events/schema.cljc
@@ -25,6 +25,7 @@
    :datascript/page-add-shortcut
    :datascript/page-remove-shortcut
    :datascript/drop-child
+   :datascript/drop-link-child
    :datascript/drop-diff-parent])
 
 
@@ -157,6 +158,15 @@
     [:map
      [:source-uid string?
       :target-eid string?]]]])
+
+
+(def datascript-drop-link-child
+  [:map
+   [:event/args
+    [:map
+     [:source-uid string?
+      :target-eid string?]]]])
+
 
 (def datascript-drop-diff-parent
   [:map

--- a/src/cljc/athens/common_events/schema.cljc
+++ b/src/cljc/athens/common_events/schema.cljc
@@ -23,7 +23,8 @@
    :datascript/paste-verbatim
    :datascript/indent
    :datascript/page-add-shortcut
-   :datascript/page-remove-shortcut])
+   :datascript/page-remove-shortcut
+   :datascript/drop-child])
 
 
 (def event-common
@@ -147,6 +148,14 @@
    [:event/args
     [:map
      [:uid string?]]]])
+
+
+(def datascript-drop-child
+  [:map
+   [:event/args
+    [:map
+     [:source-uid string?
+      :target-eid string?]]]])
 
 
 (def event

--- a/src/cljc/athens/common_events/schema.cljc
+++ b/src/cljc/athens/common_events/schema.cljc
@@ -25,6 +25,7 @@
    :datascript/page-add-shortcut
    :datascript/page-remove-shortcut
    :datascript/drop-child
+   :datascript/drop-multi-child
    :datascript/drop-link-child
    :datascript/drop-diff-parent
    :datascript/drop-link-diff-parent])
@@ -158,7 +159,15 @@
    [:event/args
     [:map
      [:source-uid string?
-      :target-eid string?]]]])
+      :target-eid int?]]]])
+
+
+(def datascript-drop-multi-child
+  [:map
+   [:event/args
+    [:map
+     [:source-uids vector?
+      :target-eid  int?]]]])
 
 
 (def datascript-drop-link-child
@@ -166,7 +175,7 @@
    [:event/args
     [:map
      [:source-uid string?
-      :target-eid string?]]]])
+      :target-eid int?]]]])
 
 
 (def datascript-drop-diff-parent
@@ -175,7 +184,7 @@
     [:map
      [:drag-target keyword?
       :source-uid  string?
-      :target-eid  string?]]]])
+      :target-eid  int?]]]])
 
 
 (def datascript-drop-link-diff-parent
@@ -184,7 +193,7 @@
     [:map
      [:drag-target keyword?
       :source-uid  string?
-      :target-eid  string?]]]])
+      :target-eid  int?]]]])
 
 
 (def event

--- a/src/cljc/athens/common_events/schema.cljc
+++ b/src/cljc/athens/common_events/schema.cljc
@@ -26,7 +26,8 @@
    :datascript/page-remove-shortcut
    :datascript/drop-child
    :datascript/drop-link-child
-   :datascript/drop-diff-parent])
+   :datascript/drop-diff-parent
+   :datascript/drop-link-diff-parent])
 
 
 (def event-common
@@ -176,6 +177,14 @@
       :source-uid  string?
       :target-eid  string?]]]])
 
+
+(def datascript-drop-link-diff-parent
+  [:map
+   [:event/args
+    [:map
+     [:drag-target keyword?
+      :source-uid  string?
+      :target-eid  string?]]]])
 
 
 (def event

--- a/src/cljc/athens/common_events/schema.cljc
+++ b/src/cljc/athens/common_events/schema.cljc
@@ -25,7 +25,7 @@
    :datascript/page-add-shortcut
    :datascript/page-remove-shortcut
    :datascript/drop-child
-   :datascript/drop-diff])
+   :datascript/drop-diff-parent])
 
 
 (def event-common
@@ -158,7 +158,7 @@
      [:source-uid string?
       :target-eid string?]]]])
 
-(def datascript-drop-diff
+(def datascript-drop-diff-parent
   [:map
    [:event/args
     [:map

--- a/src/cljc/athens/common_events/schema.cljc
+++ b/src/cljc/athens/common_events/schema.cljc
@@ -24,7 +24,8 @@
    :datascript/indent
    :datascript/page-add-shortcut
    :datascript/page-remove-shortcut
-   :datascript/drop-child])
+   :datascript/drop-child
+   :datascript/drop-diff])
 
 
 (def event-common
@@ -156,6 +157,15 @@
     [:map
      [:source-uid string?
       :target-eid string?]]]])
+
+(def datascript-drop-diff
+  [:map
+   [:event/args
+    [:map
+     [:drag-target keyword?
+      :source-uid  string?
+      :target-eid  string?]]]])
+
 
 
 (def event

--- a/src/cljc/athens/common_events/schema.cljc
+++ b/src/cljc/athens/common_events/schema.cljc
@@ -159,7 +159,7 @@
    [:event/args
     [:map
      [:source-uid string?
-      :target-eid int?]]]])
+      :target-uid string?]]]])
 
 
 (def datascript-drop-multi-child
@@ -167,7 +167,7 @@
    [:event/args
     [:map
      [:source-uids vector?
-      :target-eid  int?]]]])
+      :target-uid  string?]]]])
 
 
 (def datascript-drop-link-child
@@ -175,7 +175,7 @@
    [:event/args
     [:map
      [:source-uid string?
-      :target-eid int?]]]])
+      :target-uid string?]]]])
 
 
 (def datascript-drop-diff-parent
@@ -184,7 +184,7 @@
     [:map
      [:drag-target keyword?
       :source-uid  string?
-      :target-eid  int?]]]])
+      :target-uid  string?]]]])
 
 
 (def datascript-drop-link-diff-parent
@@ -193,7 +193,7 @@
     [:map
      [:drag-target keyword?
       :source-uid  string?
-      :target-eid  int?]]]])
+      :target-uid  string?]]]])
 
 
 (def event

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -1341,16 +1341,15 @@
   :drop-link/child
   (fn [_ [_ {:keys [source-uid target-uid] :as args}]]
     (js/console.debug ":drop-link/child args" (pr-str args))
-    (let [local?               (not (client/open?))
-          {target-eid :db/id}  (common-db/get-block  @db/dsdb [:block/uid target-uid])]
+    (let [local?               (not (client/open?))]
       (if local?
         (let [drop-link-child-event (common-events/build-drop-link-child-event -1
                                                                                source-uid
-                                                                               target-eid)
+                                                                               target-uid)
               tx               (resolver/resolve-event-to-tx @db/dsdb drop-link-child-event)]
           (js/console.debug ":drop-link/child tx" tx)
           {:fx [[:dispatch [:transact tx]]]})
-        {:fx [[:dispatch [:remote/drop-link-child source-uid target-eid]]]}))))
+        {:fx [[:dispatch [:remote/drop-link-child source-uid target-uid]]]}))))
 
 
 (defn drop-link-same-parent
@@ -1417,16 +1416,15 @@
   :drop/child
   (fn [_ [_ {:keys [source-uid target-uid] :as args}]]
     (js/console.debug ":drop/child args" (pr-str args))
-    (let [local?               (not (client/open?))
-          {target-eid :db/id}  (common-db/get-block  @db/dsdb [:block/uid target-uid])]
+    (let [local?               (not (client/open?))]
       (if local?
         (let [drop-child-event (common-events/build-drop-child-event -1
                                                                      source-uid
-                                                                     target-eid)
+                                                                     target-uid)
               tx               (resolver/resolve-event-to-tx @db/dsdb drop-child-event)]
           (js/console.debug ":drop/child tx" tx)
           {:fx [[:dispatch [:transact tx]]]})
-        {:fx [[:dispatch [:remote/drop-child source-uid target-eid]]]}))))
+        {:fx [[:dispatch [:remote/drop-child source-uid target-uid]]]}))))
 
 
 (defn between
@@ -1612,16 +1610,15 @@
   :drop-multi/child
   (fn [_ [_ {:keys [source-uids target-uid] :as args}]]
     (js/console.debug ":drop-multi/child args" (pr-str args))
-    (let [local?               (not (client/open?))
-          {target-eid :db/id}  (common-db/get-block  @db/dsdb [:block/uid target-uid])]
+    (let [local?               (not (client/open?))]
       (if local?
         (let [drop-multi-child-event (common-events/build-drop-multi-child-event -1
                                                                                  source-uids
-                                                                                 target-eid)
+                                                                                 target-uid)
               tx                     (resolver/resolve-event-to-tx @db/dsdb drop-multi-child-event)]
           (js/console.debug ":drop-multi/child tx" tx)
           {:fx [[:dispatch [:transact tx]]]})
-        {:fx [[:dispatch [:remote/drop-multi-child source-uids target-eid]]]}))))
+        {:fx [[:dispatch [:remote/drop-multi-child source-uids target-uid]]]}))))
 
 
 (reg-event-fx

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -1386,7 +1386,7 @@
   :drop/child
   (fn [_ [_ {:keys [source-uid target-uid] :as args}]]
     (js/console.debug ":drop/child args" (pr-str args))
-    (let [local?               (not (client/open?))]
+    (let [local? (not (client/open?))]
       (if local?
         (let [drop-child-event (common-events/build-drop-child-event -1
                                                                      source-uid
@@ -1401,7 +1401,7 @@
   :drop-multi/child
   (fn [_ [_ {:keys [source-uids target-uid] :as args}]]
     (js/console.debug ":drop-multi/child args" (pr-str args))
-    (let [local?               (not (client/open?))]
+    (let [local? (not (client/open?))]
       (if local?
         (let [drop-multi-child-event (common-events/build-drop-multi-child-event -1
                                                                                  source-uids
@@ -1416,12 +1416,12 @@
   :drop-link/child
   (fn [_ [_ {:keys [source-uid target-uid] :as args}]]
     (js/console.debug ":drop-link/child args" (pr-str args))
-    (let [local?               (not (client/open?))]
+    (let [local? (not (client/open?))]
       (if local?
         (let [drop-link-child-event (common-events/build-drop-link-child-event -1
                                                                                source-uid
                                                                                target-uid)
-              tx               (resolver/resolve-event-to-tx @db/dsdb drop-link-child-event)]
+              tx                    (resolver/resolve-event-to-tx @db/dsdb drop-link-child-event)]
           (js/console.debug ":drop-link/child tx" tx)
           {:fx [[:dispatch [:transact tx]]]})
         {:fx [[:dispatch [:remote/drop-link-child args]]]}))))
@@ -1437,7 +1437,7 @@
                                                                                  drag-target
                                                                                  source-uid
                                                                                  target-uid)
-              tx              (resolver/resolve-event-to-tx @db/dsdb drop-diff-parent-event)]
+              tx                     (resolver/resolve-event-to-tx @db/dsdb drop-diff-parent-event)]
           (js/console.debug ":drop/diff-parent tx" tx)
           {:fx [[:dispatch [:transact tx]]]})
         {:fx [[:dispatch [:remote/drop-diff-parent args]]]}))))
@@ -1453,7 +1453,7 @@
                                                                                            drag-target
                                                                                            source-uid
                                                                                            target-uid)
-              tx              (resolver/resolve-event-to-tx @db/dsdb drop-link-diff-parent-event)]
+              tx                          (resolver/resolve-event-to-tx @db/dsdb drop-link-diff-parent-event)]
           (js/console.debug ":drop-link/diff-parent tx" tx)
           {:fx [[:dispatch [:transact tx]]]})
         {:fx [[:dispatch [:remote/drop-link-diff-parent args]]]}))))

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -1486,19 +1486,19 @@
 
 
 (reg-event-fx
-  :drop/diff
+  :drop/diff-parent
   (fn [_ [_ {:keys [drag-target source-uid target-uid] :as args}]]
-    (js/console.debug ":drop/diff args" args)
+    (js/console.debug ":drop/diff-parent args" args)
     (let [local? (not (client/open?))]
       (if local?
-        (let [drop-diff-event (common-events/build-drop-diff-event -1
-                                                                   drag-target
-                                                                   source-uid
-                                                                   target-uid)
-              tx              (resolver/resolve-event-to-tx drop-diff-event)]
-          (js/console.debug ":drop/diff tx" tx)
+        (let [drop-diff-parent-event (common-events/build-drop-diff-parent-event -1
+                                                                                 drag-target
+                                                                                 source-uid
+                                                                                 target-uid)
+              tx              (resolver/resolve-event-to-tx drop-diff-parent-event)]
+          (js/console.debug ":drop/diff-parent tx" tx)
           {:fx [[:dispatch [:transact tx]]]})
-        {:fx [[:dispatch [:remote/drop-diff args]]]}))))
+        {:fx [[:dispatch [:remote/drop-diff-parent args]]]}))))
 
 
 

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -1337,21 +1337,6 @@
       (unindent-multi uids context-root-uid))))
 
 
-(reg-event-fx
-  :drop-link/child
-  (fn [_ [_ {:keys [source-uid target-uid] :as args}]]
-    (js/console.debug ":drop-link/child args" (pr-str args))
-    (let [local?               (not (client/open?))]
-      (if local?
-        (let [drop-link-child-event (common-events/build-drop-link-child-event -1
-                                                                               source-uid
-                                                                               target-uid)
-              tx               (resolver/resolve-event-to-tx @db/dsdb drop-link-child-event)]
-          (js/console.debug ":drop-link/child tx" tx)
-          {:fx [[:dispatch [:transact tx]]]})
-        {:fx [[:dispatch [:remote/drop-link-child source-uid target-uid]]]}))))
-
-
 (defn drop-link-same-parent
   "Create a new block with the reference to the source block, under the same parent as the source"
   [kind source parent target]
@@ -1396,21 +1381,6 @@
     {:dispatch [:transact (drop-link-same-parent kind source parent target)]}))
 
 
-(reg-event-fx
-  :drop-link/diff-parent
-  (fn [_ [_ {:keys [drag-target source-uid target-uid] :as args}]]
-    (js/console.debug ":drop-link/diff-parent args" args)
-    (let [local? (not (client/open?))]
-      (if local?
-        (let [drop-link-diff-parent-event (common-events/build-drop-link-diff-parent-event -1
-                                                                                           drag-target
-                                                                                           source-uid
-                                                                                           target-uid)
-              tx              (resolver/resolve-event-to-tx drop-link-diff-parent-event)]
-          (js/console.debug ":drop-link/diff-parent tx" tx)
-          {:fx [[:dispatch [:transact tx]]]})
-        {:fx [[:dispatch [:remote/drop-link-diff-parent args]]]}))))
-
 
 (reg-event-fx
   :drop/child
@@ -1424,8 +1394,69 @@
               tx               (resolver/resolve-event-to-tx @db/dsdb drop-child-event)]
           (js/console.debug ":drop/child tx" tx)
           {:fx [[:dispatch [:transact tx]]]})
-        {:fx [[:dispatch [:remote/drop-child source-uid target-uid]]]}))))
+        {:fx [[:dispatch [:remote/drop-child args]]]}))))
 
+
+(reg-event-fx
+  :drop-multi/child
+  (fn [_ [_ {:keys [source-uids target-uid] :as args}]]
+    (js/console.debug ":drop-multi/child args" (pr-str args))
+    (let [local?               (not (client/open?))]
+      (if local?
+        (let [drop-multi-child-event (common-events/build-drop-multi-child-event -1
+                                                                                 source-uids
+                                                                                 target-uid)
+              tx                     (resolver/resolve-event-to-tx @db/dsdb drop-multi-child-event)]
+          (js/console.debug ":drop-multi/child tx" tx)
+          {:fx [[:dispatch [:transact tx]]]})
+        {:fx [[:dispatch [:remote/drop-multi-child args]]]}))))
+
+
+(reg-event-fx
+  :drop-link/child
+  (fn [_ [_ {:keys [source-uid target-uid] :as args}]]
+    (js/console.debug ":drop-link/child args" (pr-str args))
+    (let [local?               (not (client/open?))]
+      (if local?
+        (let [drop-link-child-event (common-events/build-drop-link-child-event -1
+                                                                               source-uid
+                                                                               target-uid)
+              tx               (resolver/resolve-event-to-tx @db/dsdb drop-link-child-event)]
+          (js/console.debug ":drop-link/child tx" tx)
+          {:fx [[:dispatch [:transact tx]]]})
+        {:fx [[:dispatch [:remote/drop-link-child args]]]}))))
+
+
+(reg-event-fx
+  :drop/diff-parent
+  (fn [_ [_ {:keys [drag-target source-uid target-uid] :as args}]]
+    (js/console.debug ":drop/diff-parent args" args)
+    (let [local? (not (client/open?))]
+      (if local?
+        (let [drop-diff-parent-event (common-events/build-drop-diff-parent-event -1
+                                                                                 drag-target
+                                                                                 source-uid
+                                                                                 target-uid)
+              tx              (resolver/resolve-event-to-tx @db/dsdb drop-diff-parent-event)]
+          (js/console.debug ":drop/diff-parent tx" tx)
+          {:fx [[:dispatch [:transact tx]]]})
+        {:fx [[:dispatch [:remote/drop-diff-parent args]]]}))))
+
+
+(reg-event-fx
+  :drop-link/diff-parent
+  (fn [_ [_ {:keys [drag-target source-uid target-uid] :as args}]]
+    (js/console.debug ":drop-link/diff-parent args" args)
+    (let [local? (not (client/open?))]
+      (if local?
+        (let [drop-link-diff-parent-event (common-events/build-drop-link-diff-parent-event -1
+                                                                                           drag-target
+                                                                                           source-uid
+                                                                                           target-uid)
+              tx              (resolver/resolve-event-to-tx @db/dsdb drop-link-diff-parent-event)]
+          (js/console.debug ":drop-link/diff-parent tx" tx)
+          {:fx [[:dispatch [:transact tx]]]})
+        {:fx [[:dispatch [:remote/drop-link-diff-parent args]]]}))))
 
 (defn between
   "http://blog.jenkster.com/2013/11/clojure-less-than-greater-than-tip.html"
@@ -1474,24 +1505,6 @@
   :drop/same
   (fn [_ [_ kind source parent target]]
     {:dispatch [:transact (drop-same-parent kind source parent target)]}))
-
-
-
-(reg-event-fx
-  :drop/diff-parent
-  (fn [_ [_ {:keys [drag-target source-uid target-uid] :as args}]]
-    (js/console.debug ":drop/diff-parent args" args)
-    (let [local? (not (client/open?))]
-      (if local?
-        (let [drop-diff-parent-event (common-events/build-drop-diff-parent-event -1
-                                                                                 drag-target
-                                                                                 source-uid
-                                                                                 target-uid)
-              tx              (resolver/resolve-event-to-tx @db/dsdb drop-diff-parent-event)]
-          (js/console.debug ":drop/diff-parent tx" tx)
-          {:fx [[:dispatch [:transact tx]]]})
-        {:fx [[:dispatch [:remote/drop-diff-parent args]]]}))))
-
 
 
 (defn drop-multi-same-parent-all
@@ -1606,19 +1619,7 @@
     tx-data))
 
 
-(reg-event-fx
-  :drop-multi/child
-  (fn [_ [_ {:keys [source-uids target-uid] :as args}]]
-    (js/console.debug ":drop-multi/child args" (pr-str args))
-    (let [local?               (not (client/open?))]
-      (if local?
-        (let [drop-multi-child-event (common-events/build-drop-multi-child-event -1
-                                                                                 source-uids
-                                                                                 target-uid)
-              tx                     (resolver/resolve-event-to-tx @db/dsdb drop-multi-child-event)]
-          (js/console.debug ":drop-multi/child tx" tx)
-          {:fx [[:dispatch [:transact tx]]]})
-        {:fx [[:dispatch [:remote/drop-multi-child source-uids target-uid]]]}))))
+
 
 
 (reg-event-fx

--- a/src/cljs/athens/events/remote.cljs
+++ b/src/cljs/athens/events/remote.cljs
@@ -513,12 +513,12 @@
 
 
 (rf/reg-event-fx
-  :remote/drop-diff
+  :remote/drop-diff-parent
   (fn [{db :db} [_ drag-target source-uid target-uid]]
     (let [last-seen-tx     (:remote/last-seen-tx db)
-          drop-diff-event  (common-events/build-drop-diff-event last-seen-tx
-                                                                drag-target
-                                                                source-uid
-                                                                target-uid)]
-      (js/console.debug ":remote/drop-diff event" drop-diff-event)
-      {:fx [[:dispatch [:remote/send-event! drop-diff-event]]]})))
+          drop-diff-parent-event  (common-events/build-drop-diff-parent-event last-seen-tx
+                                                                              drag-target
+                                                                              source-uid
+                                                                              target-uid)]
+      (js/console.debug ":remote/drop-diff-parent event" drop-diff-parent-event)
+      {:fx [[:dispatch [:remote/send-event! drop-diff-parent-event]]]})))

--- a/src/cljs/athens/events/remote.cljs
+++ b/src/cljs/athens/events/remote.cljs
@@ -533,3 +533,15 @@
                                                                               target-uid)]
       (js/console.debug ":remote/drop-diff-parent event" drop-diff-parent-event)
       {:fx [[:dispatch [:remote/send-event! drop-diff-parent-event]]]})))
+
+
+(rf/reg-event-fx
+  :remote/drop-link-diff-parent
+  (fn [{db :db} [_ drag-target source-uid target-uid]]
+    (let [last-seen-tx     (:remote/last-seen-tx db)
+          drop-link-diff-parent-event  (common-events/build-drop-link-diff-parent-event last-seen-tx
+                                                                                        drag-target
+                                                                                        source-uid
+                                                                                        target-uid)]
+      (js/console.debug ":remote/drop-link-diff-parent event" drop-link-diff-parent-event)
+      {:fx [[:dispatch [:remote/send-event! drop-link-diff-parent-event]]]})))

--- a/src/cljs/athens/events/remote.cljs
+++ b/src/cljs/athens/events/remote.cljs
@@ -513,6 +513,17 @@
 
 
 (rf/reg-event-fx
+  :remote/drop-multi-child
+  (fn [{db :db} [_ source-uids target-eid]]
+    (let [last-seen-tx           (:remote/last-seen-tx db)
+          drop-multi-child-event (common-events/build-drop-multi-child-event last-seen-tx
+                                                                             source-uids
+                                                                             target-eid)]
+      (js/console.debug ":remote/drop-multi-child event" drop-multi-child-event)
+      {:fx [[:dispatch [:remote/send-event! drop-multi-child-event]]]})))
+
+
+(rf/reg-event-fx
   :remote/drop-link-child
   (fn [{db :db} [_ source-uid target-eid]]
     (let [last-seen-tx          (:remote/last-seen-tx db)

--- a/src/cljs/athens/events/remote.cljs
+++ b/src/cljs/athens/events/remote.cljs
@@ -499,3 +499,14 @@
                                                                          start
                                                                          value)]
       {:fx [[:dispatch [:remote/send-event! paste-verbatim-event]]]})))
+
+
+(rf/reg-event-fx
+  :remote/drop-child
+  (fn [{db :db} [_ source-uid target-eid]]
+    (let [last-seen-tx     (:remote/last-seen-tx db)
+          drop-child-event (common-events/build-drop-child-event last-seen-tx
+                                                                 source-uid
+                                                                 target-eid)]
+      (js/console.debug ":remote/drop-child event" drop-child-event)
+      {:fx [[:dispatch [:remote/send-event! drop-child-event]]]})))

--- a/src/cljs/athens/events/remote.cljs
+++ b/src/cljs/athens/events/remote.cljs
@@ -510,3 +510,15 @@
                                                                  target-eid)]
       (js/console.debug ":remote/drop-child event" drop-child-event)
       {:fx [[:dispatch [:remote/send-event! drop-child-event]]]})))
+
+
+(rf/reg-event-fx
+  :remote/drop-diff
+  (fn [{db :db} [_ drag-target source-uid target-uid]]
+    (let [last-seen-tx     (:remote/last-seen-tx db)
+          drop-diff-event  (common-events/build-drop-diff-event last-seen-tx
+                                                                drag-target
+                                                                source-uid
+                                                                target-uid)]
+      (js/console.debug ":remote/drop-diff event" drop-diff-event)
+      {:fx [[:dispatch [:remote/send-event! drop-diff-event]]]})))

--- a/src/cljs/athens/events/remote.cljs
+++ b/src/cljs/athens/events/remote.cljs
@@ -503,40 +503,44 @@
 
 (rf/reg-event-fx
   :remote/drop-child
-  (fn [{db :db} [_ source-uid target-eid]]
+  (fn [{db :db} [_ {:keys [source-uid target-uid] :as args}]]
+    (js/console.debug ":remote/drop-child args" (pr-str args))
     (let [last-seen-tx     (:remote/last-seen-tx db)
           drop-child-event (common-events/build-drop-child-event last-seen-tx
                                                                  source-uid
-                                                                 target-eid)]
+                                                                 target-uid)]
       (js/console.debug ":remote/drop-child event" drop-child-event)
       {:fx [[:dispatch [:remote/send-event! drop-child-event]]]})))
 
 
 (rf/reg-event-fx
   :remote/drop-multi-child
-  (fn [{db :db} [_ source-uids target-eid]]
+  (fn [{db :db} [_ {:keys [source-uids target-uid] :as args}]]
+    (js/console.debug ":remote/drop-multi-child args" (pr-str args))
     (let [last-seen-tx           (:remote/last-seen-tx db)
           drop-multi-child-event (common-events/build-drop-multi-child-event last-seen-tx
                                                                              source-uids
-                                                                             target-eid)]
+                                                                             target-uid)]
       (js/console.debug ":remote/drop-multi-child event" drop-multi-child-event)
       {:fx [[:dispatch [:remote/send-event! drop-multi-child-event]]]})))
 
 
 (rf/reg-event-fx
   :remote/drop-link-child
-  (fn [{db :db} [_ source-uid target-eid]]
+  (fn [{db :db} [_ {:keys [source-uid target-uid] :as args}]]
+    (js/console.debug ":remote/drop-link-child args" (pr-str args))
     (let [last-seen-tx          (:remote/last-seen-tx db)
           drop-link-child-event (common-events/build-drop-link-child-event last-seen-tx
                                                                            source-uid
-                                                                           target-eid)]
+                                                                           target-uid)]
       (js/console.debug ":remote/drop-link-child event" drop-link-child-event)
       {:fx [[:dispatch [:remote/send-event! drop-link-child-event]]]})))
 
 
 (rf/reg-event-fx
   :remote/drop-diff-parent
-  (fn [{db :db} [_ drag-target source-uid target-uid]]
+  (fn [{db :db} [_ {:keys [drag-target source-uid target-uid] :as args}]]
+    (js/console.debug ":remote/drop-diff-parent args" (pr-str args))
     (let [last-seen-tx     (:remote/last-seen-tx db)
           drop-diff-parent-event  (common-events/build-drop-diff-parent-event last-seen-tx
                                                                               drag-target
@@ -548,7 +552,8 @@
 
 (rf/reg-event-fx
   :remote/drop-link-diff-parent
-  (fn [{db :db} [_ drag-target source-uid target-uid]]
+  (fn [{db :db} [_ {:keys [drag-target source-uid target-uid] :as args}]]
+    (js/console.debug ":remote/drop-link-diff-parent args" (pr-str args))
     (let [last-seen-tx     (:remote/last-seen-tx db)
           drop-link-diff-parent-event  (common-events/build-drop-link-diff-parent-event last-seen-tx
                                                                                         drag-target

--- a/src/cljs/athens/events/remote.cljs
+++ b/src/cljs/athens/events/remote.cljs
@@ -513,6 +513,17 @@
 
 
 (rf/reg-event-fx
+  :remote/drop-link-child
+  (fn [{db :db} [_ source-uid target-eid]]
+    (let [last-seen-tx          (:remote/last-seen-tx db)
+          drop-link-child-event (common-events/build-drop-link-child-event last-seen-tx
+                                                                           source-uid
+                                                                           target-eid)]
+      (js/console.debug ":remote/drop-link-child event" drop-link-child-event)
+      {:fx [[:dispatch [:remote/send-event! drop-link-child-event]]]})))
+
+
+(rf/reg-event-fx
   :remote/drop-diff-parent
   (fn [{db :db} [_ drag-target source-uid target-uid]]
     (let [last-seen-tx     (:remote/last-seen-tx db)

--- a/src/cljs/athens/views/blocks/core.cljs
+++ b/src/cljs/athens/views/blocks/core.cljs
@@ -160,7 +160,8 @@
                         (and (= effect-allowed "move") (not same-parent?))        [:drop/diff-parent {:drag-target drag-target
                                                                                                       :source-uid  source-uid
                                                                                                       :target-uid  target-uid}]
-                        (and (= effect-allowed "link") (= drag-target :child))    [:drop-link/child source target]
+                        (and (= effect-allowed "link") (= drag-target :child))    [:drop-link/child {:source-uid source-uid
+                                                                                                     :target-uid target-uid}]
                         (and (= effect-allowed "link") same-parent?)              [:drop-link/same drag-target source source-parent target]
                         (and (= effect-allowed "link") (not same-parent?))        [:drop-link/diff drag-target source target target-parent])]
     (println ".event" event)

--- a/src/cljs/athens/views/blocks/core.cljs
+++ b/src/cljs/athens/views/blocks/core.cljs
@@ -150,11 +150,13 @@
     - Zero level blocks : Refers to top level blocks in a page.
     - source-uid        : The block which is being dropped.
     - target-uid        : The block on which source is being dropped.
-    - drag-target       : Where is the block being dragged see `types of events` section below.
+    - drag-target       : Represents where the block is being dragged. It can be :child meaning
+                          dragged as a child, :above meaning the source block is dropped above the
+                          target block, :below meaning the source block is dropped below the target block.
     - action-allowed    : There can be 2 types of actions.
-        - `link` action : When a block is dragged and dropped by dragging a bullet while
+        - `link` action : When a block is DnD by dragging a bullet while
                          `shift` key is pressed to create a block link.
-        - `move` action : When a block is dragged and dropped to other part of Athens page.
+        - `move` action : When a block is DnD to other part of Athens page.
 
   Types of events :
     - `:drop/same-parent`  : When a block that is under some parent (including Zero level blocks) is DnD
@@ -189,7 +191,7 @@
                         (and link-action drag-target-diff-parent?) [:drop-link/diff-parent {:drag-target drag-target
                                                                                             :source-uid  source-uid
                                                                                             :target-uid  target-uid}])]
-    (println ".event" event)
+    (println ".event" event) ;; TODO Remove this after all drop events are ported
     (rf/dispatch event)))
 
 
@@ -207,8 +209,8 @@
     - `:drop-multi/same-all`    : When the selected blocks have same parent and are DnD under the same parent
                                   this event is fired. This also applies if on selects multiple Zero level blocks
                                   and change the order among other Zero level blocks.
-    - `:drop/child`             : When the selected blocks are DnD as the first child of some other block this event is fired
-    - `:drop/diff-parent`       : When the selected blocks don't have same parent and are DnD under some other block this
+    - `:drop-multi/child`       : When the selected blocks are DnD as the first child of some other block this event is fired
+    - `:drop-multi/diff-source` : When the selected blocks don't have same parent and are DnD under some other block this
                                   event is fired."
   [source-uids target-uid drag-target]
   (let [source-uids          (mapv (comp first db/uid-and-embed-id) source-uids)
@@ -228,9 +230,8 @@
                                same-parent-source?    [:drop-multi/same-source drag-target source-uids first-source-parent target target-parent])]
     (println ".event" event)
     (rf/dispatch [:selected/clear-items])
-    (rf/dispatch event)
-    {:fx [[:dispatch [:selected/clear-items]]
-          [:dispatch event]]}))
+    (rf/dispatch event)))
+
 
 
 (defn block-drop
@@ -260,8 +261,6 @@
       (re-find #"text/plain" datatype) (when valid-text-drop
                                          (if (empty? selected-items)
                                            (drop-bullet source-uid target-uid drag-target effect-allowed)
-                                           #_(rf/dispatch [:drop source-uid target-uid drag-target effect-allowed])
-                                           #_(rf/dispatch [:drop-multi selected-items target-uid drag-target])
                                            (drop-bullet-multi selected-items target-uid drag-target))))
 
     (rf/dispatch [:mouse-down/unset])

--- a/src/cljs/athens/views/blocks/core.cljs
+++ b/src/cljs/athens/views/blocks/core.cljs
@@ -163,7 +163,9 @@
                         (and (= effect-allowed "link") (= drag-target :child))    [:drop-link/child {:source-uid source-uid
                                                                                                      :target-uid target-uid}]
                         (and (= effect-allowed "link") same-parent?)              [:drop-link/same drag-target source source-parent target]
-                        (and (= effect-allowed "link") (not same-parent?))        [:drop-link/diff drag-target source target target-parent])]
+                        (and (= effect-allowed "link") (not same-parent?))        [:drop-link/diff {:drag-target drag-target
+                                                                                                    :source-uid  source-uid
+                                                                                                    :target-uid  target-uid}])]
     (println ".event" event)
     (rf/dispatch event)))
 

--- a/src/cljs/athens/views/blocks/core.cljs
+++ b/src/cljs/athens/views/blocks/core.cljs
@@ -186,9 +186,9 @@
                         (and link-action drag-target-child?)       [:drop-link/child {:source-uid source-uid
                                                                                       :target-uid target-uid}]
                         (and link-action drag-target-same-parent?) [:drop-link/same drag-target source source-parent target]
-                        (and link-action drag-target-diff-parent?) [:drop-link/diff {:drag-target drag-target
-                                                                                     :source-uid  source-uid
-                                                                                     :target-uid  target-uid}])]
+                        (and link-action drag-target-diff-parent?) [:drop-link/diff-parent {:drag-target drag-target
+                                                                                            :source-uid  source-uid
+                                                                                            :target-uid  target-uid}])]
     (println ".event" event)
     (rf/dispatch event)))
 

--- a/src/cljs/athens/views/blocks/core.cljs
+++ b/src/cljs/athens/views/blocks/core.cljs
@@ -228,7 +228,7 @@
                                same-all?              [:drop-multi/same-all drag-target source-uids first-source-parent target]
                                diff-parents-source?   [:drop-multi/diff-source drag-target source-uids target target-parent]
                                same-parent-source?    [:drop-multi/same-source drag-target source-uids first-source-parent target target-parent])]
-    (println ".event" event)
+    (println ".event" event) ;; TODO Remove this after all events are ported
     (rf/dispatch [:selected/clear-items])
     (rf/dispatch event)))
 

--- a/src/cljs/athens/views/blocks/core.cljs
+++ b/src/cljs/athens/views/blocks/core.cljs
@@ -156,7 +156,9 @@
                         (and (= effect-allowed "move") (= drag-target :child))    [:drop/child {:source-uid source-uid
                                                                                                 :target-uid target-uid}]
                         (and (= effect-allowed "move") same-parent?)              [:drop/same drag-target source source-parent target]
-                        (and (= effect-allowed "move") (not same-parent?))        [:drop/diff drag-target source source-parent target target-parent]
+                        (and (= effect-allowed "move") (not same-parent?))        [:drop/diff {:drag-target drag-target
+                                                                                               :source-uid  source-uid
+                                                                                               :target-uid  target-uid}]
                         (and (= effect-allowed "link") (= drag-target :child))    [:drop-link/child source target]
                         (and (= effect-allowed "link") same-parent?)              [:drop-link/same drag-target source source-parent target]
                         (and (= effect-allowed "link") (not same-parent?))        [:drop-link/diff drag-target source target target-parent])]

--- a/src/cljs/athens/views/blocks/core.cljs
+++ b/src/cljs/athens/views/blocks/core.cljs
@@ -156,9 +156,10 @@
                         (and (= effect-allowed "move") (= drag-target :child))    [:drop/child {:source-uid source-uid
                                                                                                 :target-uid target-uid}]
                         (and (= effect-allowed "move") same-parent?)              [:drop/same drag-target source source-parent target]
-                        (and (= effect-allowed "move") (not same-parent?))        [:drop/diff {:drag-target drag-target
-                                                                                               :source-uid  source-uid
-                                                                                               :target-uid  target-uid}]
+
+                        (and (= effect-allowed "move") (not same-parent?))        [:drop/diff-parent {:drag-target drag-target
+                                                                                                      :source-uid  source-uid
+                                                                                                      :target-uid  target-uid}]
                         (and (= effect-allowed "link") (= drag-target :child))    [:drop-link/child source target]
                         (and (= effect-allowed "link") same-parent?)              [:drop-link/same drag-target source source-parent target]
                         (and (= effect-allowed "link") (not same-parent?))        [:drop-link/diff drag-target source target target-parent])]

--- a/test/athens/common_events/block_test.clj
+++ b/test/athens/common_events/block_test.clj
@@ -403,29 +403,6 @@
           (t/is (= "" (:block/string child-2-block)))
           (t/is (= 0 (:block/order child-2-block))))))))
 
-"Test cases for :
-
- -drop/diff-parent
-   Start:
-    -a
-     -b
-    -c
-   end:
-    -a
-     -b
-     -c
-
- -Drop/link-diff-parent
-   Start:
-    -a
-    -b
-     -c
-   end:
-    -a
-    -b
-     -c
-     -a"
-
 
 (t/deftest drop-child-test
  "Basic Case:
@@ -435,7 +412,7 @@
     End:
       -a
         -b"
-  (t/testing "Drop child test"
+  (t/testing "Drop block as first child test"
     (let [target-uid  "test-target-uid"
           target-text "a"
           source-uid  "test-source-uid"
@@ -483,7 +460,7 @@
        -a
          -b
          -c"
-  (t/testing "Drop multiple child test"
+  (t/testing "Drop multiple blocks as the first child test"
     (let [target-uid    "test-target-uid"
           target-text   "a"
           source-1-uid  "test-source-1-uid"
@@ -543,7 +520,7 @@
        -a
          -b
        -b"
-  (t/testing "Drop link child test"
+  (t/testing "Drop block reference as the first child test"
     (let [target-uid    "test-target-uid"
           target-text   "a"
           source-1-uid  "test-source-1-uid"
@@ -574,10 +551,137 @@
 
         (d/transact @fixture/connection drop-link-child-txs)
         (let [target-block       (common-db/get-block @@fixture/connection [:block/uid target-uid])
-              source-1-link-str  (str "((" source-1-uid "))")
-              linked-child-1-uid   (last (common-db/get-children-uids-recursively @@fixture/connection target-uid))
-              linked-child-1-str   (:block/string (common-db/get-block @@fixture/connection [:block/uid linked-child-1-uid]))]
-
+              source-1-ref-str   (str "((" source-1-uid "))")
+              linked-child-1-uid (last (common-db/get-children-uids-recursively @@fixture/connection target-uid))
+              linked-child-1-str (:block/string (common-db/get-block @@fixture/connection [:block/uid linked-child-1-uid]))]
           (t/is (= 1 (-> target-block :block/children count)))
-          (t/is (= source-1-link-str
+          (t/is (= source-1-ref-str
                    linked-child-1-str)))))))
+
+
+(t/deftest drop-diff-parent-test
+  "Basic Case:
+     Start with :
+       -a
+         -b
+       -c
+     End:
+       -a
+         -b
+         -c"
+
+  (t/testing "Drop block under different parent test"
+    (let [target-parent-uid "target-parent-uid"
+          target-parent-str "a"
+          target-uid        "test-target-uid"
+          target-text       "b"
+          source-uid        "test-source-uid"
+          source-text       "c"
+          setup-txs         [{:db/id          -1
+                              :node/title     "test page"
+                              :block/uid      "page-uid"
+                              :block/children [{:db/id          -2
+                                                :block/uid      target-parent-uid
+                                                :block/string   target-parent-str
+                                                :block/order    0
+                                                :block/children {:db/id          -3
+                                                                   :block/uid      target-uid
+                                                                   :block/string   target-text
+                                                                   :block/order    0
+                                                                   :block/children []}}
+                                               {:db/id          -4
+                                                :block/uid      source-uid
+                                                :block/string   source-text
+                                                :block/order    1
+                                                :block/children []}]}]]
+
+
+      (d/transact @fixture/connection setup-txs)
+      (let [source-block            (common-db/get-block @@fixture/connection [:block/uid source-uid])
+            target-block            (common-db/get-block @@fixture/connection [:block/uid target-uid])
+            target-parent-block     (common-db/get-block @@fixture/connection [:block/uid target-parent-uid])
+            drop-diff-parent-event  (common-events/build-drop-diff-parent-event -1
+                                                                          :below
+                                                                          source-uid
+                                                                          target-uid)
+            drop-diff-parent-txs    (resolver/resolve-event-to-tx @@fixture/connection drop-diff-parent-event)]
+        (t/is (= 1 (-> target-parent-block :block/children count)))
+        (t/is (= 0 (:block/order target-block)))
+        (t/is (= 1 (:block/order source-block)))
+
+        (d/transact @fixture/connection drop-diff-parent-txs)
+        (let [source-block         (common-db/get-block @@fixture/connection [:block/uid source-uid])
+              target-block         (common-db/get-block @@fixture/connection [:block/uid target-uid])
+              target-parent-block  (common-db/get-block @@fixture/connection [:block/uid target-parent-uid])]
+          (t/is (= 2 (-> target-parent-block :block/children count)))
+          (t/is (= [(select-keys target-block [:block/uid :block/order])
+                    (select-keys source-block [:block/uid :block/order])]
+                   (:block/children target-parent-block))))))))
+
+
+(t/deftest drop-link-diff-parent-test
+  "Basic Case:
+     Start with :
+       -a
+         -b
+       -c
+     End:
+       -a
+         -b
+         -c
+       -c"
+
+  (t/testing "Drop a block reference under different parent test"
+    (let [target-parent-uid "target-parent-uid"
+          target-parent-str "a"
+          target-uid        "test-target-uid"
+          target-text       "b"
+          source-uid        "test-source-uid"
+          source-text       "c"
+          setup-txs         [{:db/id          -1
+                              :node/title     "test page"
+                              :block/uid      "page-uid"
+                              :block/children [{:db/id          -2
+                                                :block/uid      target-parent-uid
+                                                :block/string   target-parent-str
+                                                :block/order    0
+                                                :block/children {:db/id          -3
+                                                                 :block/uid      target-uid
+                                                                 :block/string   target-text
+                                                                 :block/order    0
+                                                                 :block/children []}}
+                                               {:db/id          -4
+                                                :block/uid      source-uid
+                                                :block/string   source-text
+                                                :block/order    1
+                                                :block/children []}]}]]
+
+
+      (d/transact @fixture/connection setup-txs)
+      (let [source-block                 (common-db/get-block @@fixture/connection [:block/uid source-uid])
+            target-block                 (common-db/get-block @@fixture/connection [:block/uid target-uid])
+            target-parent-block          (common-db/get-block @@fixture/connection [:block/uid target-parent-uid])
+            drop-link-diff-parent-event  (common-events/build-drop-link-diff-parent-event -1
+                                                                                          :below
+                                                                                          source-uid
+                                                                                          target-uid)
+            drop-link-diff-parent-txs    (resolver/resolve-event-to-tx @@fixture/connection drop-link-diff-parent-event)]
+        (t/is (= 1 (-> target-parent-block :block/children count)))
+        (t/is (= 0 (:block/order target-block)))
+        (t/is (= 1 (:block/order source-block)))
+
+        (d/transact @fixture/connection drop-link-diff-parent-txs)
+        ;; The idea here is to find the values of all the block's string under target parent then compare it after adding
+        ;; the reference link. Comparision here is done by making a set containing the target parent's block's string and
+        ;; the expected set of strings, we then find if after joining both sets the len of this set is same as the previous set.
+        (let [source-block      (common-db/get-block @@fixture/connection [:block/uid source-uid])
+              source-ref-str    (str"((" source-uid "))")
+              target-block-str  (:block/string (common-db/get-block @@fixture/connection [:block/uid target-uid]))
+              expected-set      #{source-ref-str target-block-str}
+              linked-ref-uid    (last (common-db/get-children-uids-recursively @@fixture/connection target-parent-uid))
+              linked-ref-str    [:block/string (common-db/get-block @@fixture/connection linked-ref-uid)]
+              childrens-str-set #{linked-ref-str target-block-str}
+              union-set         (clojure.set/union expected-set childrens-str-set)]
+
+          (t/is (= 2 (-> target-parent-block :block/children count)))
+          (t/is (= 2 (count union-set))))))))

--- a/test/athens/common_events/block_test.clj
+++ b/test/athens/common_events/block_test.clj
@@ -769,15 +769,16 @@
         ;; The idea here is to find the values of all the block's string under target parent then compare it after adding
         ;; the reference link. Comparision here is done by making a set containing the target parent's block's string and
         ;; the expected set of strings, we then find if after joining both sets the len of this set is same as the previous set.
-        (let [source-block      (common-db/get-block @@fixture/connection [:block/uid source-uid])
-              source-ref-str    (str"((" source-uid "))")
-              target-block-str  (:block/string (common-db/get-block @@fixture/connection [:block/uid target-uid]))
-              expected-set      #{source-ref-str target-block-str}
-              linked-ref-uid    (last (common-db/get-children-uids-recursively @@fixture/connection target-parent-uid))
-              linked-ref-str    [:block/string (common-db/get-block @@fixture/connection linked-ref-uid)]
-              childrens-str-set #{linked-ref-str target-block-str}
-              union-set         (clojure.set/union expected-set childrens-str-set)]
+        (let [source-ref-str       (str"((" source-uid "))")
+              target-block-str     (:block/string (common-db/get-block @@fixture/connection [:block/uid target-uid]))
+              expected-set         #{source-ref-str target-block-str}
+              linked-ref-uid       (last (common-db/get-children-uids-recursively @@fixture/connection target-parent-uid))
+              linked-ref-str       (:block/string (common-db/get-block @@fixture/connection [:block/uid linked-ref-uid]))
+              childrens-str-set    #{linked-ref-str target-block-str}
+              union-set            (clojure.set/union expected-set childrens-str-set)
+              target-parent-block  (common-db/get-block @@fixture/connection [:block/uid target-parent-uid])]
 
+          (t/is (= linked-ref-str source-ref-str))
           (t/is (= 2 (-> target-parent-block :block/children count)))
           (t/is (= 2 (count union-set))))))))
 

--- a/test/athens/common_events/block_test.clj
+++ b/test/athens/common_events/block_test.clj
@@ -402,3 +402,182 @@
           (t/is (= 1 (:block/order child-1-block)))
           (t/is (= "" (:block/string child-2-block)))
           (t/is (= 0 (:block/order child-2-block))))))))
+
+"Test cases for :
+
+ -drop/diff-parent
+   Start:
+    -a
+     -b
+    -c
+   end:
+    -a
+     -b
+     -c
+
+ -Drop/link-diff-parent
+   Start:
+    -a
+    -b
+     -c
+   end:
+    -a
+    -b
+     -c
+     -a"
+
+
+(t/deftest drop-child-test
+ "Basic Case:
+    Start with :
+      -a
+      -b
+    End:
+      -a
+        -b"
+  (t/testing "Drop child test"
+    (let [target-uid  "test-target-uid"
+          target-text "a"
+          source-uid  "test-source-uid"
+          source-text "b"
+          setup-txs   [{:db/id          -1
+                        :node/title     "test page"
+                        :block/uid      "page-uid"
+                        :block/children [{:db/id          -2
+                                          :block/uid      target-uid
+                                          :block/string   target-text
+                                          :block/order    0
+                                          :block/children []}
+                                         {:db/id          -3
+                                          :block/uid      source-uid
+                                          :block/string   source-text
+                                          :block/order    1
+                                          :block/children []}]}]]
+
+
+      (d/transact @fixture/connection setup-txs)
+      (let [source-block (common-db/get-block @@fixture/connection [:block/uid source-uid])
+            target-block (common-db/get-block @@fixture/connection [:block/uid target-uid])
+            drop-child-event     (common-events/build-drop-child-event -1
+                                                                       source-uid
+                                                                       target-uid)
+            drop-child-txs   (resolver/resolve-event-to-tx @@fixture/connection drop-child-event)]
+        (t/is (= 0 (-> target-block :block/children count)))
+        (t/is (= 0 (:block/order target-block)))
+        (t/is (= 1 (:block/order source-block)))
+
+        (d/transact @fixture/connection drop-child-txs)
+        (let [source-block (common-db/get-block @@fixture/connection [:block/uid source-uid])
+              target-block (common-db/get-block @@fixture/connection [:block/uid target-uid])]
+          (t/is (= 1 (-> target-block :block/children count)))
+          (t/is (= [(select-keys source-block [:block/uid :block/order])]
+                   (:block/children target-block))))))))
+
+
+(t/deftest drop-multi-child-test
+  "Basic Case:
+       -a
+       -b
+       -c
+     End:
+       -a
+         -b
+         -c"
+  (t/testing "Drop multiple child test"
+    (let [target-uid    "test-target-uid"
+          target-text   "a"
+          source-1-uid  "test-source-1-uid"
+          source-1-text "b"
+          source-2-uid  "test-source-2-uid"
+          source-2-text "c"
+          setup-txs   [{:db/id          -1
+                        :node/title     "test page"
+                        :block/uid      "page-uid"
+                        :block/children [{:db/id          -2
+                                          :block/uid      target-uid
+                                          :block/string   target-text
+                                          :block/order    0
+                                          :block/children []}
+                                         {:db/id          -3
+                                          :block/uid      source-1-uid
+                                          :block/string   source-1-text
+                                          :block/order    1
+                                          :block/children []}
+                                         {:db/id          -4
+                                          :block/uid      source-2-uid
+                                          :block/string   source-2-text
+                                          :block/order    2
+                                          :block/children []}]}]]
+
+      (d/transact @fixture/connection setup-txs)
+      (let [target-block             (common-db/get-block @@fixture/connection [:block/uid target-uid])
+            source-1-block           (common-db/get-block @@fixture/connection [:block/uid source-1-uid])
+            source-2-block           (common-db/get-block @@fixture/connection [:block/uid source-2-uid])
+            source-uids              [source-1-uid source-2-uid]
+            drop-multi-child-event   (common-events/build-drop-multi-child-event -1
+                                                                           source-uids
+                                                                           target-uid)
+            drop-child-txs   (resolver/resolve-event-to-tx @@fixture/connection drop-multi-child-event)]
+        (t/is (= 0 (-> target-block :block/children count)))
+        (t/is (= 0 (:block/order target-block)))
+        (t/is (= 1 (:block/order source-1-block)))
+        (t/is (= 2 (:block/order source-2-block)))
+
+
+        (d/transact @fixture/connection drop-child-txs)
+        (let [target-block             (common-db/get-block @@fixture/connection [:block/uid target-uid])
+              source-1-block           (common-db/get-block @@fixture/connection [:block/uid source-1-uid])
+              source-2-block           (common-db/get-block @@fixture/connection [:block/uid source-2-uid])]
+
+          (t/is (= 2 (-> target-block :block/children count)))
+          (t/is (= [(select-keys source-1-block [:block/uid :block/order])
+                    (select-keys source-2-block [:block/uid :block/order])]
+                   (:block/children target-block))))))))
+
+
+(t/deftest drop-link-child-test
+  "Basic Case:
+       -a
+       -b
+     End:
+       -a
+         -b
+       -b"
+  (t/testing "Drop link child test"
+    (let [target-uid    "test-target-uid"
+          target-text   "a"
+          source-1-uid  "test-source-1-uid"
+          source-1-text "b"
+          setup-txs   [{:db/id          -1
+                        :node/title     "test page"
+                        :block/uid      "page-uid"
+                        :block/children [{:db/id          -2
+                                          :block/uid      target-uid
+                                          :block/string   target-text
+                                          :block/order    0
+                                          :block/children []}
+                                         {:db/id          -3
+                                          :block/uid      source-1-uid
+                                          :block/string   source-1-text
+                                          :block/order    1
+                                          :block/children []}]}]]
+      (d/transact @fixture/connection setup-txs)
+      (let [target-block            (common-db/get-block @@fixture/connection [:block/uid target-uid])
+            source-1-block          (common-db/get-block @@fixture/connection [:block/uid source-1-uid])
+            drop-link-child-event   (common-events/build-drop-link-child-event -1
+                                                                               source-1-uid
+                                                                               target-uid)
+            drop-link-child-txs   (resolver/resolve-event-to-tx @@fixture/connection drop-link-child-event)]
+        (t/is (= 0 (-> target-block :block/children count)))
+        (t/is (= 0 (:block/order target-block)))
+        (t/is (= 1 (:block/order source-1-block)))
+
+        (d/transact @fixture/connection drop-link-child-txs)
+        (let [target-block       (common-db/get-block @@fixture/connection [:block/uid target-uid])
+              source-1-link-str  (str "((" source-1-uid "))")
+              linked-child-1-uid   (last (common-db/get-children-uids-recursively @@fixture/connection target-uid))
+              linked-child-1-str   (:block/string (common-db/get-block @@fixture/connection [:block/uid linked-child-1-uid]))]
+
+          (t/is (= 1 (-> target-block :block/children count)))
+          (t/is (= source-1-link-str
+                   linked-child-1-str)))))))


### PR DESCRIPTION
This is a ~~draft~~ PR for `:drop/...` events
Port events : 

- [X] `:drop/child`
- [X] `:drop/diff`
- [x] `:drop-link/child`
- [x] `:drop-link/diff`
- [X] `:drop-multi/child`

Add test for events : 

- [x] `:drop/child`
- [x] `:drop/diff`
- [x] `:drop-link/child`
- [x] `:drop-link/diff`
- [x] `:drop-multi/child`


NOTE: Will port `:drop/same`,   `:drop-multi/same-...`, `:drop-multi/diff-source` and `:drop-link/same` in another PR because it is more complex then the ones in this PR

Alex I think you should start with this file `src/cljs/athens/views/blocks/core.cljs` it has some comments which explain the type of drop events we have and their behaviour.