### PR TITLE
Fixed a sloppy mistake of not making `:set-cursor-position` its own vector 

### DIFF
--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -1172,8 +1172,8 @@
                                                                value)
                 tx           (resolver/resolve-event-to-tx @db/dsdb indent-event)]
             (js/console.debug ":indent tx:" (pr-str tx))
-            {:fx [[:dispatch            [:transact tx]
-                   :set-cursor-position [uid start end]]]})
+            {:fx [[:dispatch            [:transact tx]]
+                  [:set-cursor-position [uid start end]]]})
           {:fx [[:dispatch [:remote/indent (merge (select-keys args [:uid])
                                                   {:start start
                                                    :end   end


### PR DESCRIPTION
effect vector